### PR TITLE
add support for complex templates (sub objects, arrays of object and operations for them)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+	// Use IntelliSense to learn about possible Node.js debug attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Program",
+			"program": "${workspaceRoot}\\test\\complexTemplate.js",
+			"cwd": "${workspaceRoot}"
+		},
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Attach to Process",
+			"port": 5858
+		}
+	]
+}

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ exports.DataTransform = function(data, map){
 				keys = key.split('.');
 				for(var i = 0; i < keys.length; i++ ) {
 					if(typeof(value) !== "undefined" && 
-						value[keys[i]]) {
+						keys[i] in value) {
 						value = value[keys[i]];
 					} else {
 						return null;

--- a/index.js
+++ b/index.js
@@ -47,24 +47,21 @@ exports.DataTransform = function(data, map){
 				return;
 			}
 
-			var value = obj || data,
-				key = key || map.list,
-				keys = null;
 			if(key == "") {
 				return;
 			} 
-
+			
 			keys = key.split('.');
-			let target = null;
+			var target = obj;
 			for(var i = 0; i < keys.length; i++ ) {
-				if(value !== "undefined" && value[keys[i]]) {
-					target = value;
-					value = value[keys[i]];
-				} else{
+				if(i == keys.length-1){
+					target[keys[i]] = newValue;
 					return;
 				}
+				if(keys[i] in target)
+					target = target[keys[i]];
+				else return;
 			}
-			target[keys[i-1]] = newValue;
 		},
 
 		getList: function(){

--- a/index.js
+++ b/index.js
@@ -37,6 +37,36 @@ exports.DataTransform = function(data, map){
 
 		},
 
+		setValue : function(obj, key, newValue) {
+
+			if(typeof(obj) == "undefined") {
+				return;
+			}
+
+			if(key == '' || key == undefined) {
+				return;
+			}
+
+			var value = obj || data,
+				key = key || map.list,
+				keys = null;
+			if(key == "") {
+				return;
+			} 
+
+			keys = key.split('.');
+			let target = null;
+			for(var i = 0; i < keys.length; i++ ) {
+				if(value !== "undefined" && value[keys[i]]) {
+					target = value;
+					value = value[keys[i]];
+				} else{
+					return;
+				}
+			}
+			target[keys[i-1]] = newValue;
+		},
+
 		getList: function(){
 			return this.getValue(data, map.list);
 		},
@@ -47,8 +77,8 @@ exports.DataTransform = function(data, map){
 			    normalized = {};
 			if(value) {
 				var list = this.getList();
-				var normalized = map.item ? _.map(list, _.bind(this.iterator, this)) : list;
-				normalized = this.operate(normalized);
+				var normalized = map.item ? _.map(list, _.bind(this.iterator, this, map.item)) : list;
+				normalized = _.bind(this.operate, this, normalized)();
 				normalized = this.each(normalized);
 			}
 		    return normalized;
@@ -58,18 +88,18 @@ exports.DataTransform = function(data, map){
 		operate: function(data) {
 
 			if(map.operate) {
-				_.each(map.operate, function(method){
-					data = _.map(data, function(item){
+				_.each(map.operate, _.bind(function(method){
+					data = _.map(data, _.bind(function(item){
 						var fn;
 						if( 'string' === typeof method.run ) {
 							fn = eval( method.run );
 						} else {
 							fn = method.run;
 						}
-						item[method.on] = fn(item[method.on]);
+						this.setValue(item,method.on,fn(this.getValue(item,method.on)))
 						return item;
-					});
-				});
+					},this));
+				},this));
 			}
 			return data;
 
@@ -82,21 +112,25 @@ exports.DataTransform = function(data, map){
 			return data;
 		},
 
-		iterator : function(item) {
+		iterator : function(map, item) {
 
 			var obj = {};
-			_.each(map.item, _.bind(function(oldkey, newkey) {
+
+			//to support simple arrays with recursion
+			if(typeof(map) == "string") {
+				return this.getValue(item, map);
+			}
+			_.each(map, _.bind(function(oldkey, newkey) {
 				if(typeof(oldkey) == "string" && oldkey.length > 0) {
 					obj[newkey] = this.getValue(item, oldkey);
 				} else if( _.isArray(oldkey) ) {
-					
-					var array = [];
-					_.each(oldkey, _.bind(function(key){
-						array.push(this.getValue(item, key));
-					},this));
+					array = _.map(oldkey, _.bind(function(item,map) {return this.iterator(map,item)}, this , item));//need to swap arguments for bind
 					obj[newkey] = array;
-					
-				} else {
+				}  else if(typeof oldkey == 'object'){
+					let bound = _.bind(this.iterator, this, oldkey,item)
+					obj[newkey] = bound();
+				}
+				else {
 					obj[newkey] = "";
 				}	
 

--- a/test/complexTemplate.js
+++ b/test/complexTemplate.js
@@ -1,0 +1,49 @@
+var DataTransform = require('../index.js').DataTransform,
+	_ = require("underscore");
+
+let map = {
+	list: 'items',
+	item: {
+		id: 'id',
+		sku: 'sku',
+		toReplace: 'sku',
+		simpleArray: ['id', 'sku','sku'],
+		complexArray: [{node: 'id'},{otherNode:'sku'},{toReplace:'sku'}],
+		subObject: {
+			node1: 'id',
+			node2: 'sku',
+			subSubObject: {
+				node1: 'id',
+				node2: 'sku',
+			}
+		}
+	},
+	operate: [{
+		run: (val)=>'replacement',
+		on: 'subObject.subSubObject.node1'
+	},
+	{
+		run: (val)=>'replacement',
+		on: 'toReplace'
+	},
+		{
+		run: (val)=>'replacement',
+		on: 'simpleArray.2'
+	},
+	{
+		run: (val)=>'replacement',
+		on: 'complexArray.2.toReplace'
+	},]
+};
+
+let object ={
+	items:[{
+	id: 'books',
+	sku:'10234-12312'
+	}]
+}
+
+let dataTransform = new DataTransform(object, map);
+let result = dataTransform.transform();
+
+console.log(JSON.stringify(result, null, 4));

--- a/test/complexTemplate.js
+++ b/test/complexTemplate.js
@@ -7,6 +7,7 @@ let map = {
 		id: 'id',
 		sku: 'sku',
 		toReplace: 'sku',
+		errorReplace: 'notFound',
 		simpleArray: ['id', 'sku','sku'],
 		complexArray: [{node: 'id'},{otherNode:'sku'},{toReplace:'sku'}],
 		subObject: {
@@ -21,6 +22,10 @@ let map = {
 	operate: [{
 		run: (val)=>'replacement',
 		on: 'subObject.subSubObject.node1'
+	},
+	{
+		run: (val)=>'replacement',
+		on: 'errorReplace'
 	},
 	{
 		run: (val)=>'replacement',

--- a/test/complexTemplate.js
+++ b/test/complexTemplate.js
@@ -6,6 +6,7 @@ let map = {
 	item: {
 		id: 'id',
 		sku: 'sku',
+		zero: 'zero',
 		toReplace: 'sku',
 		errorReplace: 'notFound',
 		simpleArray: ['id', 'sku','sku'],
@@ -44,6 +45,7 @@ let map = {
 let object ={
 	items:[{
 	id: 'books',
+	zero: 0,
 	sku:'10234-12312'
 	}]
 }


### PR DESCRIPTION
Your dead simple templates work really well. I've extended them a bit to add support for:
- sub objects (which work recursively)
- arrays of objects
- operations on sub objects, arrays and arrays of objects

It can cope with most json structure transforms now without being overly complicated. It should support all existing templates.

I've not updated the definition or the readme. I tried to follow your coding style and change as little as possible.

I've put a test file in so you can see it in action. Probably best incorporated in the existing test file though.