### PR TITLE
Nested lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,29 +2,29 @@
 
 var _ = require('lodash');
 
-exports.DataTransform = function (data, map) {
+exports.DataTransform = function(data, map){
 
 	return {
 
-		getValue: function (obj, key) {
+		getValue : function(obj, key) {
 
-			if (typeof (obj) == "undefined") {
+			if(typeof(obj) == "undefined") {
 				return "";
 			}
 
-			if (key == '' || key == undefined) {
+			if(key == '' || key == undefined) {
 				return obj;
 			}
 
 			var value = obj || data,
 				key = key || map.list,
 				keys = null;
-			if (key == "") {
+			if(key == "") {
 				value = "";
 			} else {
 				keys = key.split('.');
-				for (var i = 0; i < keys.length; i++) {
-					if (typeof (value) !== "undefined" &&
+				for(var i = 0; i < keys.length; i++ ) {
+					if(typeof(value) !== "undefined" && 
 						keys[i] in value) {
 						value = value[keys[i]];
 					} else {
@@ -32,72 +32,72 @@ exports.DataTransform = function (data, map) {
 					}
 				}
 			}
-
+			
 			return value;
 
 		},
 
-		setValue: function (obj, key, newValue) {
+		setValue : function(obj, key, newValue) {
 
-			if (typeof (obj) == "undefined") {
+			if(typeof(obj) == "undefined") {
 				return;
 			}
 
-			if (key == '' || key == undefined) {
+			if(key == '' || key == undefined) {
 				return;
 			}
 
-			if (key == "") {
+			if(key == "") {
 				return;
-			}
-
+			} 
+			
 			keys = key.split('.');
 			var target = obj;
-			for (var i = 0; i < keys.length; i++) {
-				if (i == keys.length - 1) {
+			for(var i = 0; i < keys.length; i++ ) {
+				if(i == keys.length-1){
 					target[keys[i]] = newValue;
 					return;
 				}
-				if (keys[i] in target)
+				if(keys[i] in target)
 					target = target[keys[i]];
 				else return;
 			}
 		},
 
-		getList: function () {
+		getList: function(){
 			return this.getValue(data, map.list);
 		},
 
-		transform: function () {
+		transform : function() {
 
 			var value = this.getValue(data, map.list),
-				normalized = {};
-			if (value) {
+			    normalized = {};
+			if(value) {
 				var list = this.getList();
 				var normalized = map.item ? _.map(list, _.bind(this.iterator, this, map.item)) : list;
 				normalized = _.bind(this.operate, this, normalized)();
 				normalized = _.bind(this.nested, this, normalized)();
 				normalized = this.each(normalized);
 			}
-			return normalized;
+		    return normalized;
 
 		},
 
-		operate: function (data) {
+		operate: function(data) {
 
-			if (map.operate) {
-				_.each(map.operate, _.bind(function (method) {
-					data = _.map(data, _.bind(function (item) {
+			if(map.operate) {
+				_.each(map.operate, _.bind(function(method){
+					data = _.map(data, _.bind(function(item){
 						var fn;
-						if ('string' === typeof method.run) {
-							fn = eval(method.run);
+						if( 'string' === typeof method.run ) {
+							fn = eval( method.run );
 						} else {
 							fn = method.run;
 						}
-						this.setValue(item, method.on, fn(this.getValue(item, method.on)))
+						this.setValue(item,method.on,fn(this.getValue(item,method.on)))
 						return item;
-					}, this));
-				}, this));
+					},this));
+				},this));
 			}
 			return data;
 
@@ -116,35 +116,34 @@ exports.DataTransform = function (data, map) {
 			return data;
 		},
 
-		each: function (data) {
-			if (map.each) {
+		each: function(data){
+			if( map.each ) {
 				_.each(data, map.each);
-			}
+			}  
 			return data;
 		},
 
-		iterator: function (map, item) {
+		iterator : function(map, item) {
 
 			var obj = {};
 
 			//to support simple arrays with recursion
-			if (typeof (map) == "string") {
+			if(typeof(map) == "string") {
 				return this.getValue(item, map);
 			}
-			_.each(map, _.bind(function (oldkey, newkey) {
-				if (typeof (oldkey) == "string" && oldkey.length > 0) {
+			_.each(map, _.bind(function(oldkey, newkey) {
+				if(typeof(oldkey) == "string" && oldkey.length > 0) {
 					obj[newkey] = this.getValue(item, oldkey);
-				} else if (_.isArray(oldkey)) {
-					array = _.map(oldkey, _.bind(function (item, map) {
-						return this.iterator(map, item)
-					}, this, item)); //need to swap arguments for bind
+				} else if( _.isArray(oldkey) ) {
+					array = _.map(oldkey, _.bind(function(item,map) {return this.iterator(map,item)}, this , item));//need to swap arguments for bind
 					obj[newkey] = array;
-				} else if (typeof oldkey == 'object') {
-					var bound = _.bind(this.iterator, this, oldkey, item)
+				}  else if(typeof oldkey == 'object'){
+					var bound = _.bind(this.iterator, this, oldkey,item)
 					obj[newkey] = bound();
-				} else {
-					obj[newkey] = "";
 				}
+				else {
+					obj[newkey] = "";
+				}	
 
 			}, this));
 			return obj;

--- a/index.js
+++ b/index.js
@@ -2,29 +2,29 @@
 
 var _ = require('lodash');
 
-exports.DataTransform = function(data, map){
+exports.DataTransform = function (data, map) {
 
 	return {
 
-		getValue : function(obj, key) {
+		getValue: function (obj, key) {
 
-			if(typeof(obj) == "undefined") {
+			if (typeof (obj) == "undefined") {
 				return "";
 			}
 
-			if(key == '' || key == undefined) {
+			if (key == '' || key == undefined) {
 				return obj;
 			}
 
 			var value = obj || data,
 				key = key || map.list,
 				keys = null;
-			if(key == "") {
+			if (key == "") {
 				value = "";
 			} else {
 				keys = key.split('.');
-				for(var i = 0; i < keys.length; i++ ) {
-					if(typeof(value) !== "undefined" && 
+				for (var i = 0; i < keys.length; i++) {
+					if (typeof (value) !== "undefined" &&
 						keys[i] in value) {
 						value = value[keys[i]];
 					} else {
@@ -32,104 +32,119 @@ exports.DataTransform = function(data, map){
 					}
 				}
 			}
-			
+
 			return value;
 
 		},
 
-		setValue : function(obj, key, newValue) {
+		setValue: function (obj, key, newValue) {
 
-			if(typeof(obj) == "undefined") {
+			if (typeof (obj) == "undefined") {
 				return;
 			}
 
-			if(key == '' || key == undefined) {
+			if (key == '' || key == undefined) {
 				return;
 			}
 
-			if(key == "") {
+			if (key == "") {
 				return;
-			} 
-			
+			}
+
 			keys = key.split('.');
 			var target = obj;
-			for(var i = 0; i < keys.length; i++ ) {
-				if(i == keys.length-1){
+			for (var i = 0; i < keys.length; i++) {
+				if (i == keys.length - 1) {
 					target[keys[i]] = newValue;
 					return;
 				}
-				if(keys[i] in target)
+				if (keys[i] in target)
 					target = target[keys[i]];
 				else return;
 			}
 		},
 
-		getList: function(){
+		getList: function () {
 			return this.getValue(data, map.list);
 		},
 
-		transform : function() {
+		transform: function () {
 
 			var value = this.getValue(data, map.list),
-			    normalized = {};
-			if(value) {
+				normalized = {};
+			if (value) {
 				var list = this.getList();
 				var normalized = map.item ? _.map(list, _.bind(this.iterator, this, map.item)) : list;
 				normalized = _.bind(this.operate, this, normalized)();
+				normalized = _.bind(this.nested, this, normalized)();
 				normalized = this.each(normalized);
 			}
-		    return normalized;
+			return normalized;
 
 		},
 
-		operate: function(data) {
+		operate: function (data) {
 
-			if(map.operate) {
-				_.each(map.operate, _.bind(function(method){
-					data = _.map(data, _.bind(function(item){
+			if (map.operate) {
+				_.each(map.operate, _.bind(function (method) {
+					data = _.map(data, _.bind(function (item) {
 						var fn;
-						if( 'string' === typeof method.run ) {
-							fn = eval( method.run );
+						if ('string' === typeof method.run) {
+							fn = eval(method.run);
 						} else {
 							fn = method.run;
 						}
-						this.setValue(item,method.on,fn(this.getValue(item,method.on)))
+						this.setValue(item, method.on, fn(this.getValue(item, method.on)))
 						return item;
-					},this));
-				},this));
+					}, this));
+				}, this));
 			}
 			return data;
 
 		},
 
-		each: function(data){
-			if( map.each ) {
-				_.each(data, map.each);
-			}  
+		nested: function (data) {
+			if (map.nested) {
+				_.each(map.nested, _.bind(function (nestDefinition) {
+					data = _.map(data, _.bind(function (item) {
+						var dataTransform = exports.DataTransform(item, nestDefinition);
+						this.setValue(item, nestDefinition.list, dataTransform.transform());
+						return item;
+					}, this));
+				}, this));
+			}
 			return data;
 		},
 
-		iterator : function(map, item) {
+		each: function (data) {
+			if (map.each) {
+				_.each(data, map.each);
+			}
+			return data;
+		},
+
+		iterator: function (map, item) {
 
 			var obj = {};
 
 			//to support simple arrays with recursion
-			if(typeof(map) == "string") {
+			if (typeof (map) == "string") {
 				return this.getValue(item, map);
 			}
-			_.each(map, _.bind(function(oldkey, newkey) {
-				if(typeof(oldkey) == "string" && oldkey.length > 0) {
+			_.each(map, _.bind(function (oldkey, newkey) {
+				if (typeof (oldkey) == "string" && oldkey.length > 0) {
 					obj[newkey] = this.getValue(item, oldkey);
-				} else if( _.isArray(oldkey) ) {
-					array = _.map(oldkey, _.bind(function(item,map) {return this.iterator(map,item)}, this , item));//need to swap arguments for bind
+				} else if (_.isArray(oldkey)) {
+					array = _.map(oldkey, _.bind(function (item, map) {
+						return this.iterator(map, item)
+					}, this, item)); //need to swap arguments for bind
 					obj[newkey] = array;
-				}  else if(typeof oldkey == 'object'){
-					var bound = _.bind(this.iterator, this, oldkey,item)
+				} else if (typeof oldkey == 'object') {
+					var bound = _.bind(this.iterator, this, oldkey, item)
 					obj[newkey] = bound();
-				}
-				else {
+				} else {
 					obj[newkey] = "";
-				}	
+				}
 
 			}, this));
 			return obj;

--- a/test/nestedTester.js
+++ b/test/nestedTester.js
@@ -1,0 +1,111 @@
+var DataTransform = require('../index.js').DataTransform,
+	_ = require("underscore");
+
+let map = {
+	list: 'items',
+	item: {
+		id: 'id',
+		sku: 'sku',
+		zero: 'zero',
+		toReplace: 'sku',
+		errorReplace: 'notFound',
+		simpleArray: ['id', 'sku', 'sku'],
+		complexArray: [{
+			node: 'id'
+		}, {
+			otherNode: 'sku'
+		}, {
+			toReplace: 'sku'
+		}],
+		subObject: {
+			node1: 'id',
+			node2: 'sku',
+			subSubObject: {
+				node1: 'id',
+				node2: 'sku',
+			}
+		},
+		others: 'duplicates',
+		deeplyNested: {
+			list: 'deep.duplicates'
+		},
+		nest: 'nested'
+	},
+	nested: [{
+		list: 'others',
+		item: {
+			newSKU: 'sku',
+			newID: 'id'
+		}
+
+	}, {
+		list: 'deeplyNested.list',
+		item: {
+			newSKU: 'sku',
+			newID: 'id'
+		}
+	}, {
+		list: 'nest',
+		item: {
+			skus: 'skus',
+			newID: 'id'
+		},
+		nested: [{
+			list: 'skus',
+			item: {
+				alternateSKU: 'subSKU',
+			}
+		}]
+	},
+	{
+		list: 'others',
+		item: {
+			newSKU: 'sku',
+			newID: 'id'
+		}
+
+	}]
+};
+
+let object = {
+	items: [{
+		id: 'books',
+		zero: 0,
+		sku: '10234-12312',
+		duplicates: [{
+			id: 'otherBook',
+			sku: '10234-12313'
+		}, {
+			id: 'thirdBook',
+			sku: '10234-12314'
+		}],
+		deep: {
+			duplicates: [{
+				id: 'otherBook',
+				sku: '10234-12313'
+			}, {
+				id: 'thirdBook',
+				sku: '10234-12314'
+			}]
+		},
+		nested: [{
+			id: 'otherBook',
+			skus: [{
+				subSKU: '1023'
+			}]
+		}, {
+			id: 'thirdBook',
+			skus: [{
+				subSKU: '1024'
+			},
+			{
+				subSKU: '1023'
+			}]
+		}]
+	}]
+}
+
+let dataTransform = new DataTransform(object, map);
+let result = dataTransform.transform();
+
+console.log(JSON.stringify(result, null, 4));


### PR DESCRIPTION
Added the nested keyword. Doesn't really add much new code.

Appears to work for recursively nested lists for free (although it gets ugly quickly). Is also compatible with the complex templates layout.

Syntax is:
```
{	
	list: 'listName',
	item: {
		//map
		nestedList: 'referenceToNestedList'
	},
	nested: [{
		list: 'nestedList',
		item: {
			//map
		}
		//whatever you can normally use
	}]
}
```

You have to copy the list over using the normal map at the moment. Adding a ```to:``` node would mean you could reference the source data and avoid this line. In two minds about whether that is a good idea. 

Limitation is you can't reference anything outside the nested list. This has the potential to get messy if done wrong.