### PR TITLE
Fixing unexpected usage of es6 arrow functions in published file

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.DataTransform = function(data, map){
 
 		getValue : function(obj, key, newKey) {
 
-			if(typeof(obj) == "undefined") {
+			if(typeof obj === 'undefined') {
 				return;
 			}
 
@@ -20,11 +20,12 @@ exports.DataTransform = function(data, map){
 				return obj;
 			}
 
-			var value = obj || data,
-				key = key || map.list,
-				keys = null;
-			if(key == "") {
-				value = "";
+			var value = obj || data;
+			var keys = null;
+
+			key = key || map.list;
+			if(key == '') {
+				value = '';
 			} else {
 				keys = key.split('.');
 				for(var i = 0; i < keys.length; i++ ) {
@@ -43,7 +44,7 @@ exports.DataTransform = function(data, map){
 
 		setValue : function(obj, key, newValue) {
 
-			if(typeof(obj) == "undefined") {
+			if(typeof obj === "undefined") {
 				return;
 			}
 
@@ -51,14 +52,14 @@ exports.DataTransform = function(data, map){
 				return;
 			}
 
-			if(key == "") {
+			if(key == '') {
 				return;
 			} 
 			
-			keys = key.split('.');
+			var keys = key.split('.');
 			var target = obj;
 			for(var i = 0; i < keys.length; i++ ) {
-				if(i == keys.length-1){
+				if(i === keys.length - 1) {
 					target[keys[i]] = newValue;
 					return;
 				}
@@ -74,12 +75,12 @@ exports.DataTransform = function(data, map){
 
 		transform : function(context) {
 
-			var value = this.getValue(data, map.list),
-					normalized = {};
+			var value = this.getValue(data, map.list);
+			var normalized = {};
 					
 			if(value) {
 				var list = this.getList();
-				var normalized = map.item ? _.map(list, _.bind(this.iterator, this, map.item)) : list;
+				normalized = map.item ? _.map(list, _.bind(this.iterator, this, map.item)) : list;
 				normalized = _.bind(this.operate, this, normalized)(context);
 				normalized = this.each(normalized, context);
 				normalized = this.removeAll(normalized);
@@ -97,7 +98,7 @@ exports.DataTransform = function(data, map){
 		},
 
 		remove: function(item){
-			_.each(map.remove, (key)=>{
+			_.each(map.remove, function (key) {
 				delete item[key];
 			});
 			return item;
@@ -114,7 +115,7 @@ exports.DataTransform = function(data, map){
 						} else {
 							fn = method.run;
 						}
-						this.setValue(item,method.on,fn(this.getValue(item,method.on), context))
+						this.setValue(item,method.on,fn(this.getValue(item,method.on), context));
 						return item;
 					},this));
 				},this));
@@ -125,7 +126,9 @@ exports.DataTransform = function(data, map){
 
 		each: function(data, context){
 			if( map.each ) {
-				_.each(data, (value, index, collection) => map.each(value, index, collection, context));
+				_.each(data, function (value, index, collection) {
+					return map.each(value, index, collection, context);
+				});
 			}  
 			return data;
 		},
@@ -135,17 +138,17 @@ exports.DataTransform = function(data, map){
 			var obj = {};
 
 			//to support simple arrays with recursion
-			if(typeof(map) == "string") {
+			if(typeof map === 'string') {
 				return this.getValue(item, map);
 			}
 			_.each(map, _.bind(function(oldkey, newkey) {
-				if(typeof(oldkey) == "string" && oldkey.length > 0) {
+				if(typeof oldkey === 'string' && oldkey.length > 0) {
 					obj[newkey] = this.getValue(item, oldkey, newkey);
 				} else if( _.isArray(oldkey) ) {
-					array = _.map(oldkey, _.bind(function(item,map) {return this.iterator(map,item)}, this , item));//need to swap arguments for bind
+					var array = _.map(oldkey, _.bind(function(item,map) {return this.iterator(map,item)}, this , item));//need to swap arguments for bind
 					obj[newkey] = array;
-				}  else if(typeof oldkey == 'object'){
-					var bound = _.bind(this.iterator, this, oldkey,item)
+				}  else if(typeof oldkey === 'object'){
+					var bound = _.bind(this.iterator, this, oldkey,item);
 					obj[newkey] = bound();
 				}
 				else {


### PR DESCRIPTION
Somehow arrow functions have creeped into the code with the recent additions and won't be transpiled when used as part of other packages.

Those were removed and some small cleanup of the code has taken place as well