### PR TITLE
Uses loadash _get() for source traversal

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,22 +24,7 @@ exports.DataTransform = function(data, map){
 			var keys = null;
 
 			key = key || map.list;
-			if(key == '') {
-				value = '';
-			} else {
-				keys = key.split('.');
-				for(var i = 0; i < keys.length; i++ ) {
-					if(typeof(value) !== "undefined" && 
-						keys[i] in value) {
-						value = value[keys[i]];
-					} else {
-						return this.defaultOrNull(newKey);
-					}
-				}
-			}
-			
-			return value;
-
+			return key == '' ? '' :  _.get(value, key, this.defaultOrNull(newKey));
 		},
 
 		setValue : function(obj, key, newValue) {

--- a/test/nodeDataTransformSpec.js
+++ b/test/nodeDataTransformSpec.js
@@ -391,4 +391,31 @@ describe("node-json-transform", function() {
 
 	});
 
+	it("should allow for dots in object keys", function (){
+		var data = {
+			input: [
+				{ key: { 'dot.key': 'peter' } },
+				{ key: { 'dot.key': 'paul' } },
+				{ key: { 'dot.key': 'marry' } }
+			]
+		};
+
+		var map = {
+			list: 'input',
+			item: {
+				name: 'key["dot.key"]'
+			}
+		};
+
+		var dataTransform = DataTransform(data, map);
+
+		var result = dataTransform.transform();
+
+		expect(result).toEqual([
+			{name: "peter"},
+			{name: "paul"},
+			{name: "marry"}
+		]);
+	});
+
 });


### PR DESCRIPTION
One data parsing library used in one of my projects generates objects with `.` in the key names.  The existing object traversal splits the key on `.` and treats each item in the array as the key to use for descending.  This causes a key that _requires_ a `.` to become split and an incorrect traversal to be performed.

I have replaced the tree traversal with lodash's `_get()` to provide more robustness.